### PR TITLE
Move submodule update back to dedicated workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -1,0 +1,46 @@
+name: Check submodules updates
+
+on:
+  schedule:
+    - cron: 0 4 * * *
+  repository_dispatch:
+    types: [ check-submodules ]
+  workflow_dispatch:
+
+jobs:
+  check-submodules:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        submodule:
+          - Abstractions
+          - Common
+          - DayTemplate
+          - Year2018
+          - Year2019
+          - Year2020
+          - Year2021
+          - Year2022
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+          submodules: true
+      - name: Checkout submodule to latest main state
+        run: git -C ${{ matrix.submodule }} checkout main
+      - name: Get commit hash after submodule update
+        run: echo "COMMIT_HASH=$(git -C ${{ matrix.submodule }} rev-parse --short HEAD)" >> $GITHUB_ENV
+      - name: Create pull request with changes
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: Updated ${{ matrix.submodule }} submodule to ${{ env.COMMIT_HASH }}
+          branch: update-${{ matrix.submodule }}-submodule
+          delete-branch: true
+          title: Update ${{ matrix.submodule }} submodule
+          body: Automated update of ${{ matrix.submodule }} submodule to its latest version
+          labels: |
+            dependencies
+            submodules
+          assignees: mMosiur
+          reviewers: mMosiur


### PR DESCRIPTION
Dependabot would be a preferred solution but as of right now it does not allow for updating existing PR, instead it closes and creates a new superceding one which bloats up PRs quickly when submodule is updated frequently (as e.g. when advent of code event is in progress).
Related issue on dependabot repo: dependabot/dependabot-core#2264